### PR TITLE
Add length restriction to migration file

### DIFF
--- a/db/migrate/20180331073323_create_kazutori_counts.rb
+++ b/db/migrate/20180331073323_create_kazutori_counts.rb
@@ -6,7 +6,7 @@ class CreateKazutoriCounts < ActiveRecord::Migration[5.1]
       t.datetime :hour
 
       t.timestamps
-      t.index [:countable_type, :countable_id, :hour], unique: true, name: "index_coutable_hour"
+      t.index [:countable_type, :countable_id, :hour], unique: true, name: "index_coutable_hour", length: {countable_type: 191}
     end
   end
 end


### PR DESCRIPTION
If database's "DEFAULT CHARSET" is "utf8mb4", the error occurs like below when migrate,
```
ActiveRecord::StatementInvalid: Mysql2::Error: Specified key was too long; max key length is 767 bytes
```
Therefore, I added character length restriction to migration file.

Before:
```
t.index [:countable_type, :countable_id, :hour], unique: true, name: "index_coutable_hour"
```

After:
```
t.index [:countable_type, :countable_id, :hour], unique: true, name: "index_coutable_hour", length: {countable_type: 191}
```
Thank you.